### PR TITLE
fix: bug in the dfs logic

### DIFF
--- a/src/app/services/item_service.py
+++ b/src/app/services/item_service.py
@@ -228,7 +228,7 @@ def get_item_by_id_dfs_iterative(
 
                     for task in lab.tasks:
                         counter += 1
-                        if lab.id == item_id:
+                        if task.id == item_id:
                             return FoundItem(task, counter)
 
                         for step in task.steps:


### PR DESCRIPTION
## Summary

Fixed a bug in the `get_item_by_id_dfs_iterative` function when searching for an item by ID.

In the task loop, the wrong identifier was being checked — `lab.id` instead of `task.id`. This caused the search by task ID to always return 404, even if the task existed.

- Closes #4 

---

## Changes

- Fixed ID check in `get_item_by_id_dfs_iterative`
- Now correctly checks `task.id` instead of `lab.id`

---

## Checklist

- [x] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [x] I see `base: main` &lt;- `compare: fix-dfs-bug` above the PR title.
- [x] I edited the line `- Closes #4 
- [x] I wrote clear commit messages.
- [x] I reviewed my own diff before requesting review.
- [x] I understand the changes I'm submitting.